### PR TITLE
Update README snippet and rename iconsetName to iconSetName

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ Gulp plugin that generates an `<iron-iconset-svg>` given a group of .svg icon fi
 ## Usage
 
 Install it with npm
-    
+
     npm install gulp-polymer-iconset
 
 In your <code>gulpfile.js</code>:
 
 ```javascript
-var polymerIconset = require('gulp-polymer-iconset'),
-    rename = require('gulp-rename');
+var gulp = require('gulp'),
+    polymerIconset = require('gulp-polymer-iconset'),
+    path = require('path');
 
 gulp.task('styles', function(){
   return gulp.src('app/icons/**/*')
@@ -19,7 +20,7 @@ gulp.task('styles', function(){
         iconSetName: 'my-icons',
         iconSize: 18,
         iconId: function (file) {
-            return 'my-icons' + ':' + path.basename(file.path, '.svg');
+            return path.basename(file.path, '.svg');
         },
     }))
     .pipe(gulp.dest('app/iconsets'));
@@ -34,7 +35,7 @@ It results in:
 <iron-iconset-svg name="my-icons" size="18">
   <svg>
     <defs>
-        
+
 <!-- my-icons:icon-01 -->
 <g id="my-icons:icon-01">
   <polygon points="..."/>

--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ function polymerIconset(options) {
     _.defaults(options, DEFAULT_OPTIONS);
 
     // check for required options
-    if (!options.iconsetName) {
+    if (!options.iconSetName) {
         throw new gulpUtil.PluginError(
             'gulp-polymer-iconset',
-            'iconsetName option is required'
+            'iconSetName option is required'
         );
     }
 
@@ -52,9 +52,9 @@ function polymerIconset(options) {
     function bufferContents(file, encoding, cb) {
 
         // evaluate options according to file
-        var iconId = (typeof options.iconId === 'function') ? 
+        var iconId = (typeof options.iconId === 'function') ?
             options.iconId(file) : options.iconId;
-        var iconSelector = (typeof options.iconSelector === 'function') ? 
+        var iconSelector = (typeof options.iconSelector === 'function') ?
             options.iconSelector(file) : options.iconSelector;
 
         if (file.isNull()) {
@@ -122,7 +122,7 @@ function polymerIconset(options) {
 
         // create the file object
         var file = new gulpUtil.File({
-            path: options.iconsetName + '.html',
+            path: options.iconSetName + '.html',
             contents: new Buffer(iconSetHtml),
         });
 


### PR DESCRIPTION
Hi guys,

`gulp-rename` is used nowhere so I removed it whereas the `path = require('path')` was missing.

Regarding the `iconId`, the polymer element's name doesn't figure in it (cf [this polycast](https://youtu.be/tjmRUgUca1g?t=1m9s)).

And finally, I renamed `iconsetName` as `iconSetName` in the index.js so it would match how the other variables are named. 

PS: This is my first pull request so let me know if I did something wrong.
